### PR TITLE
Task4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'redis'
 gem 'sanitize'
 gem 'will_paginate', '~> 3.1.0'
 gem 'letter_opener'
+gem 'pry-byebug'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -23,6 +23,10 @@ class ProjectsController < ProjectsBaseController
       team: current_user.team,
       public_feed: params[:visibility] == 'Public'
     )
+    new_project_user = ProjectUser.new(project_id: project.id, user_id: current_user.id)
+    project.project_users.push(new_project_user)
+    new_project_user.save
+    project.save
 
     flash[:success] = 'Project created'
     return redirect_to dashboard_path

--- a/app/src/projects_for_user.rb
+++ b/app/src/projects_for_user.rb
@@ -4,6 +4,13 @@
 # * being a superuser
 # * being in the approved users list for a project
 
+# 1. #projects returns all the project in the same team
+# 2. in projects_from_same_team
+    # 1) super user can see everything
+    # 2) project with empty project_user list, can be seen by
+    #    anyone, in case all the project_user is deleted
+    # 3) user in the project_user list, can see the project (creater and the user added to the project manully)
+
 class ProjectsForUser
   def initialize(user)
     @user = user

--- a/app/src/projects_for_user.rb
+++ b/app/src/projects_for_user.rb
@@ -3,6 +3,7 @@
 # * being on the same team
 # * being a superuser
 # * being in the approved users list for a project
+
 class ProjectsForUser
   def initialize(user)
     @user = user


### PR DESCRIPTION
Something need to be clarified, in task 4:

> We'd like it so that only the user that created **the release** can see the project.".

Is here the "release" to be corrected to "project"? A user has to see the project first, before creating a release. 

Based on this understanding, my goal is that, ONLY give default access permission to the user who create the project. Two modifications:
1. when a new project is creating, instead of giving an empty project_users, a default project_users is generated, linking the current_user and the new project together. (project_users act like a joining table, for N:N relations between projects and users)
2. I checked app/src/projects_for_user.rb. The logic is still correct. I add some comments to explain in that file.

After these two steps, accounts can only access projects they created. And the creator can add a new user to his project to share, as in the screenshots:

**John's account with his projects and shared project**
![W Webbernet](https://user-images.githubusercontent.com/98811623/170298686-7e556a08-2f1a-4447-9791-fca9d7bc78b0.png)

**Ethan's account with his projects and shared project**
![Pasted Graphic 1](https://user-images.githubusercontent.com/98811623/170298742-a21b32c2-1f2e-45a8-bc14-f7c1c811e9e3.png)

